### PR TITLE
Add 'grunt watch' and live reload to the tests HTML.

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -102,6 +102,16 @@ module.exports = function(grunt) {
           src: 'dist/stampit.js',
           dest: 'dist/stampit.min.js'
       }
+    },
+
+    watch: {
+      options: {
+        livereload: true
+      },
+      scripts: {
+        files: ['./stampit.js', './test/stampit-specs.js', './mixinchain.js'],
+        tasks: ['default']
+      }
     }
   });
 
@@ -110,6 +120,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-contrib-uglify');
+  grunt.loadNpmTasks('grunt-contrib-watch');
   // grunt.loadNpmTasks('grunt-lexicon');
 
   grunt.registerTask('hint', ['jshint']);

--- a/package.json
+++ b/package.json
@@ -25,11 +25,12 @@
   },
   "devDependencies": {
     "grunt": "~0.4.1",
-    "grunt-saucelabs": "~8.4.1",
     "grunt-browserify": "~1.2.1",
-    "grunt-contrib-jshint": "~0.6.2",
     "grunt-contrib-connect": "~0.3.0",
-    "grunt-contrib-uglify": "~0.2.5"
+    "grunt-contrib-jshint": "~0.6.2",
+    "grunt-contrib-uglify": "~0.2.5",
+    "grunt-contrib-watch": "^0.6.1",
+    "grunt-saucelabs": "~8.4.1"
   },
   "scripts": {
     "test": "scripts/test.sh"

--- a/test/index.html
+++ b/test/index.html
@@ -50,5 +50,6 @@
 <script>var a = stampit();
 var b = a();</script>
 <script src="stampit-specs.js"></script>
+<script src="http://localhost:35729/livereload.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Simplifying development.
`grunt watch` to automate linting and build. And livereload to the unit test page to avoid F5 key strokes.